### PR TITLE
Added optional input file environment variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+Features:
+
+  - added an optional input file environment variable
+
 ## 0.0.5 (2017-04-24)
 
 Features:

--- a/README.md
+++ b/README.md
@@ -67,6 +67,14 @@ also assumes module support through the
 package manager is installed on the running compute node as well as the
 requested module in `$PARAVIEW_MODULE`.
 
+### INPUT_FILE
+
+*Optional*
+
+If this environment variable is set, then Paraview will attempt to load the
+file path specified in this variable. This can be an absolute path or relative
+to the user's home directory.
+
 ## Contributing
 
 1. Fork it ( https://github.com/OSC/bc_osc_paraview/fork )

--- a/template/xstartup
+++ b/template/xstartup
@@ -18,7 +18,11 @@ module load ${PARAVIEW_MODULE}
 #
 
 module load virtualgl
-vglrun paraview
+if [[ ${INPUT_FILE} ]]; then
+  vglrun paraview --data=${INPUT_FILE}
+else
+  vglrun paraview
+fi
 
 # Kill vncserver when user closes GUI
 vncserver -kill ${DISPLAY}


### PR DESCRIPTION
The environment variable `INPUT_FILE` can be defined to launch Paraview with this given file.