### PR TITLE
[DO NOT MERGE] modify to launch Owens vis with input file

### DIFF
--- a/form.yml
+++ b/form.yml
@@ -1,15 +1,18 @@
 ---
 title: "Paraview"
-cluster: "quick"
+cluster: "owens"
 description: |
-  This app will launch Paraview on an Owens **shared node**. You will be able
+  This app will launch Paraview on an Owens compute node. You will be able
   to interact with Paraview through a VNC session.
 attributes:
+  inputfile:
+    required: true
   bc_vnc_resolution:
     required: true
   bc_account:
     help: "You can leave this blank if **not** in multiple projects."
+
 form:
-  - bc_num_hours
+  - inputfile
   - bc_account
   - bc_vnc_resolution

--- a/submit.yml.erb
+++ b/submit.yml.erb
@@ -4,7 +4,8 @@ batch_connect:
 
 script:
   job_environment:
-    PARAVIEW_MODULE: "paraview/4.4.0"
+    PARAVIEW_MODULE: "paraview/5.3.0"
+    INPUT_FILE: "<%= inputfile %>"
   native:
     resources:
-      nodes: "1:ppn=1:oakley"
+      nodes: "1:ppn=28:gpus=1:vis"

--- a/template/script.sh
+++ b/template/script.sh
@@ -57,4 +57,4 @@ module load ${PARAVIEW_MODULE}
 
 # Launch Paraview
 module load virtualgl
-vglrun paraview
+vglrun paraview --data=$INPUT_FILE


### PR DESCRIPTION
This is an example of how to modify Paraview to accept a single input file in an iHPC session.

To launch the app you generate HTML that looks like this:

```erb
<html>
<head>
<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
</head>
<body>

<%
base_url = "/pun/sys/dashboard/batch_connect/dev/tsparaview-launcher"
inputfile = "/users/PZS0562/efranz/awesim/dev/tsparaview/wrp.exo"
resolution = "2048x1152"
%>

<form action="<%= base_url %>/session_contexts" method="POST" target="_blank">
    <input type="hidden" name="batch_connect_session_context[inputfile]" value="<%= inputfile %>">
    <input type="hidden" name="batch_connect_session_context[bc_vnc_resolution]"      value="<%= resolution %>">
<!--  <input type="hidden" name="batch_connect_session_context[bc_account]"    value="PZS0530"> -->
    <input type="hidden" name="authenticity_token"  value="">
    <input type="submit" value="View input file in Paraview">
  </form>

<script>
$.get("<%= base_url %>/session_contexts/new", function(data){
  var token = $(data).filter("meta[name=csrf-token]").attr("content");
  $('input[name=authenticity_token]').val(token);
});
</script>
</body>
</html>
```

1. This assumes that my paraview batch connect "app" is deployed to ~awesim/dev/tsparaview-launcher.
2. If I were to create a shared app and it was at ~efranz/awesim/share/tsparaview-launcher then the base URL would be  /pun/sys/dashboard/batch_connect/usr/efranz/tsparaview-launcher not /pun/sys/dashboard/batch_connect/dev/tsparaview-launcher

The javascript gets the csrf token and sets it. There is a race condition that should be provided here: after setting the csrf token, you will want to enable the form submit button. Disable the button by default. And if getting the token fails, display an error to the user instead i.e. asking the user to reload, because they might need to login again.