### PR TITLE
change account to a select widget that only has valid groups

### DIFF
--- a/form.yml.erb
+++ b/form.yml.erb
@@ -1,16 +1,25 @@
+<%-
+  groups = OodSupport::User.new.groups.sort_by(&:id).tap { |groups|
+    groups.unshift(groups.delete(OodSupport::Process.group))
+  }.map(&:name).grep(/^P./)
+-%>
 ---
 cluster: "owens"
 form:
   - version
-  - bc_account
+  - account
   - bc_num_hours
   - bc_vnc_resolution
 attributes:
   bc_vnc_resolution:
     required: true
-  bc_account:
+  account:
     label: "Project"
-    help: "You can leave this blank if **not** in multiple projects."
+    widget: select
+    options:
+      <%- groups.each do |group| %>
+      - "<%= group %>"
+      <%- end %>
   version:
     widget: select
     label: "Paraview Version"

--- a/submit.yml.erb
+++ b/submit.yml.erb
@@ -5,6 +5,7 @@
 batch_connect:
   template: vnc
 script:
+  accounting_id: "<%= account %>"
   native:
     <%- args.each do |arg| -%>
     - "<%= arg %>"


### PR DESCRIPTION
This changes the account field to be a select widget for only valid project codes to help users only use valid project codes while forcing them to supply one.