### PR TITLE
export dbus-launch to properly init xfce

### DIFF
--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -15,6 +15,8 @@ cd "${HOME}"
   export XDG_CONFIG_HOME="<%= session.staged_root.join("config") %>"
   export XDG_DATA_HOME="<%= session.staged_root.join("share") %>"
   export XDG_CACHE_HOME="$(mktemp -d)"
+  export $(dbus-launch)
+
   xfwm4 --compositor=off --daemon --sm-client-disable
   xsetroot -solid "#D3D3D3"
   xfsettingsd --sm-client-disable


### PR DESCRIPTION
export dbus-launch to properly init xfce windowing libraries.